### PR TITLE
IDP-Adding project examples page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gem "jekyll"  , "~> 4.4.1" # installed by `gem jekyll`
 
 # gem "just-the-docs", "0.10.1" # pinned to the current release
 gem "just-the-docs"        # always download the latest release
-
+gem "bigdecimal"
+gem "logger"
 # Get rid of the scss stylesheet warnings...
 gem "jekyll-sass-converter", "~> 2.2"
 gem "sassc", "~> 2.4.0"  # Ensure sassc is used instead of Dart Sass

--- a/idp/final-project/handouts/project_examples.md
+++ b/idp/final-project/handouts/project_examples.md
@@ -1,0 +1,23 @@
+---
+layout: default_dl
+parent: IDP - Final Project
+title: Project Examples
+nav_order: 56
+---
+
+# Project Examples
+
+This folder contains previous projects that were done for IDP in the 2023-24 school year. You can _pull inspiration_ from these projects, but your final result should **NOT** be a copy of these nor similar to them. They are sectioned off by each step of the project. Note that the requirements are subject to change, and thus these projects may not be an accurate reflection of what work you will have to do.
+
+General folder link: [https://drive.google.com/drive/folders/12xauPUfAQIYjcHBSxNT6cykoz9rDyue5?usp=drive_link](https://drive.google.com/drive/folders/12xauPUfAQIYjcHBSxNT6cykoz9rDyue5?usp=drive_link)
+
+* [Design Document Examples](https://drive.google.com/drive/folders/12ol7hrO46mWxx-iCMUNBmFemYdKHoD2I?usp=drive_link)
+* [Plot Sketch Examples](https://drive.google.com/drive/folders/1nkkm2kdY44p_tJyNpXMs0Y2FDGoJSF5M?usp=drive_link)
+* [Final Report Examples](https://drive.google.com/drive/folders/1VcgU5-3dYg49XE2jFsa3bdBKlMeoAoc5?usp=drive_link)
+* [Presentation Slidedeck Examples](https://drive.google.com/drive/folders/1jK5PkfPLY9mCfhtx1PUvbR7aeWJeIj9x?usp=sharing)
+
+Credits to:
+* _Exploring Factors Affecting Literacy Rates & Disparities Across Countries_ by Mahir Emran & Saanika Fadia
+
+
+


### PR DESCRIPTION
Page contains project examples and is found under the IDP - Final Project tab, below Research. More examples will be added as I get them from people.

Gemfile was updated to include bigdecimal and logger since they were being loaded from the standard library on my end.